### PR TITLE
Updates to tell users to explicitly set 2021.4.1

### DIFF
--- a/src/pages/300-integration-api-enabled-application-integration/demo-preparation.mdx
+++ b/src/pages/300-integration-api-enabled-application-integration/demo-preparation.mdx
@@ -59,7 +59,7 @@ Install Cloud Pak for Integration, or provision a ROKS environment. To reserve y
 
 <br/>
 
-2. After you are logged in, click <a href="https://cloud.ibm.com/catalog/content/ibm-cp-integration-72f63273-f2f6-4e9c-8626-60fe798c57be-global" target="_blank" rel="noreferrer">here</a> to install Cloud Pak for Integration.<br/><br/>Make sure you are in an **ITZ** account (1) and the **Product version** is the latest version available (2).<br/><img src="https://raw.githubusercontent.com/ibm-garage-tsa/platinum-demos/master/src/pages/300-integration-api-enabled-application-integration/images/prep-image2.2.png" width="800" />
+2. After you are logged in, click <a href="https://cloud.ibm.com/catalog/content/ibm-cp-integration-72f63273-f2f6-4e9c-8626-60fe798c57be-global" target="_blank" rel="noreferrer">here</a> to install Cloud Pak for Integration.<br/><br/>Make sure you are in an **ITZ** account (1) and the **Product version** is **2021.4.1-2** (2).<br/><img src="https://raw.githubusercontent.com/ibm-garage-tsa/platinum-demos/master/src/pages/300-integration-api-enabled-application-integration/images/prep-image2.2.png" width="800" />
 
 <br/>
 

--- a/src/pages/300-integration-cloud-native-integration/demo-preparation.mdx
+++ b/src/pages/300-integration-cloud-native-integration/demo-preparation.mdx
@@ -65,7 +65,7 @@ If you have issues connecting to your instance, contact <a href="https://ibm-clo
 
 <br/>
 
-2. Ensure the product version is the latest version available (in the screenshot below, for example, 2021.4.1-0).
+2. Ensure the product version is **2021.4.1-2**.
 <br/><br/><img src="https://raw.githubusercontent.com/ibm-garage-tsa/platinum-demos/master/src/pages/300-integration-cloud-native-integration/images/cp4i-version.png" width="800" />
 
 <br/>

--- a/src/pages/300-integration-low-code-integration-using-ai/demo-preparation.mdx
+++ b/src/pages/300-integration-low-code-integration-using-ai/demo-preparation.mdx
@@ -66,7 +66,7 @@ Install Cloud Pak for Integration, or provision a ROKS environment. To reserve y
 
 <br/>
 
-2. After you are logged in, click <a href="https://cloud.ibm.com/catalog/content/ibm-cp-integration-72f63273-f2f6-4e9c-8626-60fe798c57be-global" target="_blank" rel="noreferrer">here</a> to install Cloud Pak for Integration.<br/>Make sure you are in an **ITZ** account (1) and the **Product version** is the latest version available (2).<br/><img src="https://raw.githubusercontent.com/ibm-garage-tsa/platinum-demos/master/src/pages/300-integration-low-code-integration-using-ai/images/prep-image2.2.png" width="800" />
+2. After you are logged in, click <a href="https://cloud.ibm.com/catalog/content/ibm-cp-integration-72f63273-f2f6-4e9c-8626-60fe798c57be-global" target="_blank" rel="noreferrer">here</a> to install Cloud Pak for Integration.<br/>Make sure you are in an **ITZ** account (1) and the **Product version** is **2021.4.1-2** (2).<br/><img src="https://raw.githubusercontent.com/ibm-garage-tsa/platinum-demos/master/src/pages/300-integration-low-code-integration-using-ai/images/prep-image2.2.png" width="800" />
 
 <br/>
 


### PR DESCRIPTION
The product team have released an updated version of the Cloud Pak for Integration and there is a small correction to all of the instructions. 